### PR TITLE
Add manuel commit to prevent early commit

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -208,8 +208,8 @@ func (c *consumer) Stop() error {
 		}
 		c.quit <- struct{}{}
 		close(c.messageCh)
-		err = c.r.Close()
 		c.wg.Wait()
+		err = c.r.Close()
 	})
 
 	return err


### PR DESCRIPTION
If you get any panic from the code, the offset will be forwarded already thus we are going to miss some events. Instead, we need to commit only processed messages.