### PR TITLE
feat: add functionality pause and resume for consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ manager ([kafka-cronsumer](https://github.com/Trendyol/kafka-cronsumer)).
 - Added ability for manipulating kafka message headers.
 - Added transactional retry feature. Set false if you want to use exception/retry strategy to only failed messages.
 - Enable manuel commit at both single and batch consuming modes.
+- Enabling consumer resume/pause functionality. Please refer to [its example](examples/with-pause-resume-consumer) and
+[how it works](examples/with-pause-resume-consumer/how-it-works.md) documentation.
 - Bumped [kafka-cronsumer](https://github.com/Trendyol/kafka-cronsumer/releases) to the latest version:
   - Backoff strategy support (linear, exponential options)
   - Added message key for retried messages 
@@ -196,6 +198,10 @@ After running `docker-compose up` command, you can run any application you want.
 #### With Distributed Tracing Support
 
 Please refer to [Tracing Example](examples/with-tracing/README.md)
+
+#### With Pause & Resume Consumer
+
+Please refer to [Pause Resume Example](examples/with-pause-resume-consumer)
 
 #### With Grafana & Prometheus
 

--- a/batch_consumer.go
+++ b/batch_consumer.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"context"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -19,15 +18,11 @@ type batchConsumer struct {
 }
 
 func (b *batchConsumer) Pause() {
-	b.logger.Info("Batch consumer is paused!")
-	b.pauseConsuming = true
-	b.cancelFn()
+	b.base.Pause()
 }
 
 func (b *batchConsumer) Resume() {
-	b.logger.Info("Batch consumer is resumed!")
-	b.pauseConsuming = false
-	b.context, b.cancelFn = context.WithCancel(context.Background())
+	b.base.Resume()
 }
 
 func newBatchConsumer(cfg *ConsumerConfig) (Consumer, error) {

--- a/batch_consumer.go
+++ b/batch_consumer.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -15,6 +16,18 @@ type batchConsumer struct {
 	preBatchFn PreBatchFn
 
 	messageGroupLimit int
+}
+
+func (b *batchConsumer) Pause() {
+	b.logger.Info("Batch consumer is paused!")
+	b.pauseConsuming = true
+	b.cancelFn()
+}
+
+func (b *batchConsumer) Resume() {
+	b.logger.Info("Consumer is resumed!")
+	b.pauseConsuming = false
+	b.context, b.cancelFn = context.WithCancel(context.Background())
 }
 
 func newBatchConsumer(cfg *ConsumerConfig) (Consumer, error) {

--- a/batch_consumer.go
+++ b/batch_consumer.go
@@ -25,7 +25,7 @@ func (b *batchConsumer) Pause() {
 }
 
 func (b *batchConsumer) Resume() {
-	b.logger.Info("Consumer is resumed!")
+	b.logger.Info("Batch consumer is resumed!")
 	b.pauseConsuming = false
 	b.context, b.cancelFn = context.WithCancel(context.Background())
 }

--- a/batch_consumer_test.go
+++ b/batch_consumer_test.go
@@ -362,16 +362,21 @@ func Test_batchConsumer_Pause(t *testing.T) {
 		base: &base{
 			logger:   NewZapLogger(LogLevelDebug),
 			context:  ctx,
+			pause:    make(chan struct{}),
 			cancelFn: cancelFn,
 		},
 	}
+
+	go func() {
+		<-bc.base.pause
+	}()
 
 	// When
 	bc.Pause()
 
 	// Then
-	if bc.base.pauseConsuming != true {
-		t.Fatal("pauseConsuming must be true!")
+	if bc.base.consumerState != statePaused {
+		t.Fatal("consumer state must be in paused")
 	}
 }
 
@@ -390,8 +395,8 @@ func Test_batchConsumer_Resume(t *testing.T) {
 	bc.Resume()
 
 	// Then
-	if bc.base.pauseConsuming != false {
-		t.Fatal("pauseConsuming must be false!")
+	if bc.base.consumerState != stateRunning {
+		t.Fatal("consumer state must be in resume!")
 	}
 }
 

--- a/batch_consumer_test.go
+++ b/batch_consumer_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strconv"
@@ -351,6 +352,46 @@ func Test_batchConsumer_chunk(t *testing.T) {
 				t.Errorf("For chunkSize %d, expected %v, but got %v", tc.chunkSize, tc.expected, chunkedMessages)
 			}
 		})
+	}
+}
+
+func Test_batchConsumer_Pause(t *testing.T) {
+	// Given
+	ctx, cancelFn := context.WithCancel(context.Background())
+	bc := batchConsumer{
+		base: &base{
+			logger:   NewZapLogger(LogLevelDebug),
+			context:  ctx,
+			cancelFn: cancelFn,
+		},
+	}
+
+	// When
+	bc.Pause()
+
+	// Then
+	if bc.base.pauseConsuming != true {
+		t.Fatal("pauseConsuming must be true!")
+	}
+}
+
+func Test_batchConsumer_Resume(t *testing.T) {
+	// Given
+	ctx, cancelFn := context.WithCancel(context.Background())
+	bc := batchConsumer{
+		base: &base{
+			logger:   NewZapLogger(LogLevelDebug),
+			context:  ctx,
+			cancelFn: cancelFn,
+		},
+	}
+
+	// When
+	bc.Resume()
+
+	// Then
+	if bc.base.pauseConsuming != false {
+		t.Fatal("pauseConsuming must be false!")
 	}
 }
 

--- a/batch_consumer_test.go
+++ b/batch_consumer_test.go
@@ -360,10 +360,10 @@ func Test_batchConsumer_Pause(t *testing.T) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	bc := batchConsumer{
 		base: &base{
-			logger:   NewZapLogger(LogLevelDebug),
-			context:  ctx,
-			pause:    make(chan struct{}),
-			cancelFn: cancelFn,
+			logger:  NewZapLogger(LogLevelDebug),
+			pause:   make(chan struct{}),
+			context: ctx, cancelFn: cancelFn,
+			consumerState: stateRunning,
 		},
 	}
 
@@ -382,12 +382,16 @@ func Test_batchConsumer_Pause(t *testing.T) {
 
 func Test_batchConsumer_Resume(t *testing.T) {
 	// Given
+	mc := mockReader{}
 	ctx, cancelFn := context.WithCancel(context.Background())
 	bc := batchConsumer{
 		base: &base{
-			logger:   NewZapLogger(LogLevelDebug),
-			context:  ctx,
-			cancelFn: cancelFn,
+			r:       &mc,
+			logger:  NewZapLogger(LogLevelDebug),
+			pause:   make(chan struct{}),
+			quit:    make(chan struct{}),
+			wg:      sync.WaitGroup{},
+			context: ctx, cancelFn: cancelFn,
 		},
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -12,6 +13,18 @@ type consumer struct {
 	*base
 
 	consumeFn func(*Message) error
+}
+
+func (c *consumer) Pause() {
+	c.logger.Info("Consumer is paused!")
+	c.pauseConsuming = true
+	c.cancelFn()
+}
+
+func (c *consumer) Resume() {
+	c.logger.Info("Consumer is resumed!")
+	c.pauseConsuming = false
+	c.context, c.cancelFn = context.WithCancel(context.Background())
 }
 
 func newSingleConsumer(cfg *ConsumerConfig) (Consumer, error) {

--- a/consumer.go
+++ b/consumer.go
@@ -48,6 +48,7 @@ func newSingleConsumer(cfg *ConsumerConfig) (Consumer, error) {
 
 func (c *consumer) Consume() {
 	go c.subprocesses.Start()
+
 	c.wg.Add(1)
 	go c.startConsume()
 

--- a/consumer.go
+++ b/consumer.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"context"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -16,15 +15,11 @@ type consumer struct {
 }
 
 func (c *consumer) Pause() {
-	c.logger.Info("Consumer is paused!")
-	c.pauseConsuming = true
-	c.cancelFn()
+	c.base.Pause()
 }
 
 func (c *consumer) Resume() {
-	c.logger.Info("Consumer is resumed!")
-	c.pauseConsuming = false
-	c.context, c.cancelFn = context.WithCancel(context.Background())
+	c.base.Resume()
 }
 
 func newSingleConsumer(cfg *ConsumerConfig) (Consumer, error) {

--- a/consumer_base.go
+++ b/consumer_base.go
@@ -20,10 +20,10 @@ type Consumer interface {
 	// Consume starts consuming
 	Consume()
 
-	// Pause pauses consumer, it is stop consuming new messages
+	// Pause function pauses consumer, it is stop consuming new messages
 	Pause()
 
-	// Resume resumes consumer, it is start to working
+	// Resume function resumes consumer, it is start to working
 	Resume()
 
 	// WithLogger for injecting custom log implementation

--- a/consumer_base.go
+++ b/consumer_base.go
@@ -164,6 +164,18 @@ func (c *base) startConsume() {
 	}
 }
 
+func (c *base) Pause() {
+	c.logger.Info("Consumer is paused!")
+	c.pauseConsuming = true
+	c.cancelFn()
+}
+
+func (c *base) Resume() {
+	c.logger.Info("Consumer is resumed!")
+	c.pauseConsuming = false
+	c.context, c.cancelFn = context.WithCancel(context.Background())
+}
+
 func (c *base) WithLogger(logger LoggerInterface) {
 	c.logger = logger
 }

--- a/consumer_base.go
+++ b/consumer_base.go
@@ -179,7 +179,6 @@ func (c *base) Pause() {
 	c.cancelFn()
 
 	c.pause <- struct{}{}
-	close(c.pause)
 
 	c.consumerState = statePaused
 }
@@ -200,7 +199,7 @@ func (c *base) WithLogger(logger LoggerInterface) {
 }
 
 func (c *base) Stop() error {
-	c.logger.Info("Stop called!")
+	c.logger.Info("Stop is called!")
 
 	var err error
 	c.once.Do(func() {
@@ -208,7 +207,7 @@ func (c *base) Stop() error {
 		c.cancelFn()
 
 		// In order to save cpu, we break startConsume loop in pause mode.
-		// If consumer is pause mode, and Stop called
+		// If consumer is pause mode and Stop is called
 		// We need to close incomingMessageStream, because c.wg.Wait() blocks indefinitely.
 		if c.consumerState == stateRunning {
 			c.quit <- struct{}{}

--- a/consumer_base_test.go
+++ b/consumer_base_test.go
@@ -3,11 +3,12 @@ package kafka
 import (
 	"context"
 	"errors"
-	"github.com/google/go-cmp/cmp"
-	"github.com/segmentio/kafka-go"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/segmentio/kafka-go"
 )
 
 func Test_base_startConsume(t *testing.T) {

--- a/consumer_base_test.go
+++ b/consumer_base_test.go
@@ -57,6 +57,43 @@ func Test_base_startConsume(t *testing.T) {
 	})
 }
 
+func Test_base_Pause(t *testing.T) {
+	// Given
+	ctx, cancelFn := context.WithCancel(context.Background())
+	b := base{
+		logger: NewZapLogger(LogLevelDebug), pauseConsuming: false,
+		context: ctx, cancelFn: cancelFn,
+	}
+
+	// When
+	b.Pause()
+
+	// Then
+	if b.pauseConsuming != true {
+		t.Fatal("pauseConsuming must be true!")
+	}
+}
+
+func Test_base_Resume(t *testing.T) {
+	// Given
+	ctx, cancelFn := context.WithCancel(context.Background())
+	b := base{
+		logger: NewZapLogger(LogLevelDebug), pauseConsuming: false,
+		context: ctx, cancelFn: cancelFn,
+	}
+
+	// When
+	b.Resume()
+
+	// Then
+	if b.pauseConsuming != false {
+		t.Fatal("pauseConsuming must be true!")
+	}
+	if ctx == b.context {
+		t.Fatal("contexts must be differ!")
+	}
+}
+
 type mockReader struct {
 	wantErr bool
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -113,4 +114,44 @@ func Test_consumer_process(t *testing.T) {
 			t.Fatalf("Total Unprocessed Message Counter must equal to 1")
 		}
 	})
+}
+
+func Test_consumer_Pause(t *testing.T) {
+	// Given
+	ctx, cancelFn := context.WithCancel(context.Background())
+	c := consumer{
+		base: &base{
+			logger:   NewZapLogger(LogLevelDebug),
+			context:  ctx,
+			cancelFn: cancelFn,
+		},
+	}
+
+	// When
+	c.Pause()
+
+	// Then
+	if c.base.pauseConsuming != true {
+		t.Fatal("pauseConsuming must be true!")
+	}
+}
+
+func Test_consumer_Resume(t *testing.T) {
+	// Given
+	ctx, cancelFn := context.WithCancel(context.Background())
+	c := consumer{
+		base: &base{
+			logger:   NewZapLogger(LogLevelDebug),
+			context:  ctx,
+			cancelFn: cancelFn,
+		},
+	}
+
+	// When
+	c.Resume()
+
+	// Then
+	if c.base.pauseConsuming != false {
+		t.Fatal("pauseConsuming must be false!")
+	}
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -122,17 +122,21 @@ func Test_consumer_Pause(t *testing.T) {
 	c := consumer{
 		base: &base{
 			logger:   NewZapLogger(LogLevelDebug),
+			pause:    make(chan struct{}),
 			context:  ctx,
 			cancelFn: cancelFn,
 		},
 	}
+	go func() {
+		<-c.base.pause
+	}()
 
 	// When
 	c.Pause()
 
 	// Then
-	if c.base.pauseConsuming != true {
-		t.Fatal("pauseConsuming must be true!")
+	if c.base.consumerState != statePaused {
+		t.Fatal("consumer state must be in paused")
 	}
 }
 
@@ -151,7 +155,7 @@ func Test_consumer_Resume(t *testing.T) {
 	c.Resume()
 
 	// Then
-	if c.base.pauseConsuming != false {
-		t.Fatal("pauseConsuming must be false!")
+	if c.base.consumerState != stateRunning {
+		t.Fatal("consumer state must be in running")
 	}
 }

--- a/examples/with-pause-resume-consumer/how-it-works.md
+++ b/examples/with-pause-resume-consumer/how-it-works.md
@@ -1,0 +1,30 @@
+Before implementation, I researched [segmentio/kafka-go](https://github.com/segmentio/kafka-go)' issues for this 
+functionality.  I came across [this issue](https://github.com/segmentio/kafka-go/issues/474). [Achille-roussel](https://github.com/achille-roussel)
+who is the old maintainer of the kafka-go clearly said that 
+
+```
+To pause consuming from a partition, you can simply stop reading 
+messages. Kafka does not have a concept of pausing or resuming in its protocol, the responsibility is given to clients 
+to decide what to read and when.
+```
+
+It means, if we stop calling `FetchMessage`, the consumer pauses. If we invoke, the consumer resumes. Here, there is very
+important behaviour exist. Consumer group state not affected at all in this situation. When we call `kafka.NewConsumer`,
+segmentio/kafka-go library creates a goroutine under the hood, and it starts to send heartbeat with a specific interval
+so even if we stop calling `FetchMessage`, consumer group still stable mode and not consumes new message at all.
+
+```go
+consumer, _ := kafka.NewConsumer(consumerCfg)
+defer consumer.Stop()
+
+consumer.Consume()
+fmt.Println("Consumer started...!")
+```
+
+If you need to implement Pause & Resume functionality on your own applications, you need to call `Consume`. Because this
+method creates listeners goroutine under the hood. After that you can manage the lifecycle of the consumer by calling
+`Pause` and `Resume` methods.
+
+You can run the example to see `Is consumer consumes new message in Pause mode` or `consumer consumes new message in Resume mode`
+by producing dummy messages on kowl ui.
+

--- a/examples/with-pause-resume-consumer/main.go
+++ b/examples/with-pause-resume-consumer/main.go
@@ -33,15 +33,16 @@ func main() {
 
 		time.Sleep(10 * time.Second)
 		consumer.Resume()
+		/*
+			time.Sleep(10 * time.Second)
+			consumer.Pause()
 
-		time.Sleep(10 * time.Second)
-		consumer.Pause()
+				time.Sleep(10 * time.Second)
+				consumer.Resume()
 
-		time.Sleep(10 * time.Second)
-		consumer.Resume()
-
-		time.Sleep(10 * time.Second)
-		consumer.Pause()
+				time.Sleep(10 * time.Second)
+				consumer.Pause()
+		*/
 	}()
 
 	c := make(chan os.Signal, 1)

--- a/examples/with-pause-resume-consumer/main.go
+++ b/examples/with-pause-resume-consumer/main.go
@@ -33,16 +33,15 @@ func main() {
 
 		time.Sleep(10 * time.Second)
 		consumer.Resume()
-		/*
-			time.Sleep(10 * time.Second)
-			consumer.Pause()
 
-				time.Sleep(10 * time.Second)
-				consumer.Resume()
+		time.Sleep(10 * time.Second)
+		consumer.Pause()
 
-				time.Sleep(10 * time.Second)
-				consumer.Pause()
-		*/
+		time.Sleep(10 * time.Second)
+		consumer.Resume()
+
+		time.Sleep(10 * time.Second)
+		consumer.Pause()
 	}()
 
 	c := make(chan os.Signal, 1)

--- a/examples/with-pause-resume-consumer/main.go
+++ b/examples/with-pause-resume-consumer/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"github.com/Trendyol/kafka-konsumer/v2"
+	"os"
+	"os/signal"
+	"time"
+)
+
+func main() {
+	consumerCfg := &kafka.ConsumerConfig{
+		Concurrency: 1,
+		Reader: kafka.ReaderConfig{
+			Brokers: []string{"localhost:29092"},
+			Topic:   "standart-topic",
+			GroupID: "standart-cg",
+		},
+		RetryEnabled: false,
+		ConsumeFn:    consumeFn,
+	}
+
+	consumer, _ := kafka.NewConsumer(consumerCfg)
+	defer consumer.Stop()
+
+	consumer.Consume()
+	fmt.Println("Consumer started...!")
+
+	// You can produce a message via kowl.
+	go func() {
+		time.Sleep(10 * time.Second)
+		consumer.Pause()
+
+		time.Sleep(10 * time.Second)
+		consumer.Resume()
+
+		time.Sleep(10 * time.Second)
+		consumer.Pause()
+
+		time.Sleep(10 * time.Second)
+		consumer.Resume()
+
+		time.Sleep(10 * time.Second)
+		consumer.Pause()
+	}()
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	<-c
+}
+
+func consumeFn(message *kafka.Message) error {
+	fmt.Printf("Message From %s with value %s \n", message.Topic, string(message.Value))
+	return nil
+}


### PR DESCRIPTION
Based on [this issue](https://github.com/Trendyol/kafka-konsumer/issues/77) and some internal projects, I implemented a `pause/resume` consuming mechanism.

Before implementation, I researched segmentio/kafka-go issues for this functionality. I came across [this issue](https://github.com/segmentio/kafka-go/issues/474). [achille-roussel](https://github.com/achille-roussel) answer is really clear. If I stop calling `FetchMessage,` the consumer pauses. If I invoke `FetchMessage,` it resumes. Consumer group is still Stable because when I called `kafka.NewConsumer`, segmentio creates a goroutine and starts heartbeat to the broker under the hood!

First, I defined two methods, `Resume` and `Pause` on the Consumer interface. So our clients can invoke this easily. You can refer to examples/with-pause-resume-consumer/main.go. It basically

```go
consumer, _ := kafka.NewConsumer(consumerCfg)
defer consumer.Stop()

consumer.Consume()
fmt.Println("Consumer started...!")

go func() {
  time.Sleep(10 * time.Second)
  consumer.Pause()
  
  time.Sleep(10 * time.Second)
  consumer.Resume()
  
  time.Sleep(10 * time.Second)
  consumer.Pause()
  
  time.Sleep(10 * time.Second)
  consumer.Resume()
  
  time.Sleep(10 * time.Second)
  consumer.Pause()
}()
```

I also added related documentation within the example.
