### PR TITLE
feat: remove spaces from broker lists implementation

### DIFF
--- a/consumer_config.go
+++ b/consumer_config.go
@@ -87,6 +87,12 @@ func (cfg ReaderConfig) JSON() string {
 		cfg.MaxWait, cfg.CommitInterval, kcronsumer.ToStringOffset(cfg.StartOffset))
 }
 
+func (cfg *ReaderConfig) removeSpaceBrokerList() {
+	for i := range cfg.Brokers {
+		cfg.Brokers[i] = strings.TrimSpace(cfg.Brokers[i])
+	}
+}
+
 func (cfg *ConsumerConfig) JSON() string {
 	if cfg == nil {
 		return "{}"
@@ -271,7 +277,10 @@ func (cfg *ConsumerConfig) newKafkaReader() (Reader, error) {
 		return nil, err
 	}
 
+	cfg.Reader.removeSpaceBrokerList()
+
 	readerCfg := kafka.ReaderConfig(cfg.Reader)
+
 	readerCfg.Dialer = dialer
 	if cfg.Rack != "" {
 		readerCfg.GroupBalancers = []kafka.GroupBalancer{kafka.RackAffinityGroupBalancer{Rack: cfg.Rack}}

--- a/consumer_config_test.go
+++ b/consumer_config_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -354,6 +355,48 @@ func TestConsumerConfig_JSONPretty(t *testing.T) {
 			t.Fatal("result must be equal to expected")
 		}
 	})
+}
+
+func TestConsumerConfig_removeSpaceBrokerList(t *testing.T) {
+	type fields struct {
+		Reader ReaderConfig
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		expected []string
+	}{
+		{
+			name: "Should_Remove_Spaces_In_Broker_Lists",
+			fields: fields{
+				Reader: ReaderConfig{Brokers: []string{" address", "address ", " address "}},
+			},
+			expected: []string{"address", "address", "address"},
+		},
+		{
+			name: "Should_Do_Nothing_When_Broker_Lists_Have_Not_Any_Space",
+			fields: fields{
+				Reader: ReaderConfig{Brokers: []string{"address1", "address2", "address3"}},
+			},
+			expected: []string{"address1", "address2", "address3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			cfg := &ConsumerConfig{
+				Reader: tt.fields.Reader,
+			}
+
+			// When
+			cfg.Reader.removeSpaceBrokerList()
+
+			// Then
+			if !reflect.DeepEqual(cfg.Reader.Brokers, tt.expected) {
+				t.Errorf("For broker list %v, expected %v", cfg.Reader.Brokers, tt.expected)
+			}
+		})
+	}
 }
 
 func getConsumerConfigExample() *ConsumerConfig {

--- a/producer.go
+++ b/producer.go
@@ -23,6 +23,7 @@ type producer struct {
 }
 
 func NewProducer(cfg *ProducerConfig, interceptors ...ProducerInterceptor) (Producer, error) {
+	cfg.Writer.removeSpaceBrokerList()
 	kafkaWriter := &kafka.Writer{
 		Addr:                   kafka.TCP(cfg.Writer.Brokers...),
 		Topic:                  cfg.Writer.Topic,

--- a/producer_config.go
+++ b/producer_config.go
@@ -37,6 +37,12 @@ func (cfg WriterConfig) JSON() string {
 		strings.Join(cfg.Brokers, "\", \""), GetBalancerString(cfg.Balancer), cfg.Compression.String())
 }
 
+func (cfg *WriterConfig) removeSpaceBrokerList() {
+	for i := range cfg.Brokers {
+		cfg.Brokers[i] = strings.TrimSpace(cfg.Brokers[i])
+	}
+}
+
 type TransportConfig struct {
 	MetadataTopics []string
 	DialTimeout    time.Duration

--- a/producer_config_test.go
+++ b/producer_config_test.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/segmentio/kafka-go"
@@ -88,6 +89,48 @@ func TestProducerConfig_JsonPretty(t *testing.T) {
 			t.Fatal("result must be equal to expected")
 		}
 	})
+}
+
+func TestProducerConfig_removeSpaceBrokerList(t *testing.T) {
+	type fields struct {
+		Brokers []string
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		expected []string
+	}{
+		{
+			name: "Should_Remove_Spaces_In_Broker_Lists",
+			fields: fields{
+				Brokers: []string{" address", "address ", " address "},
+			},
+			expected: []string{"address", "address", "address"},
+		},
+		{
+			name: "Should_Do_Nothing_When_Broker_Lists_Have_Not_Any_Space",
+			fields: fields{
+				Brokers: []string{"address1", "address2", "address3"},
+			},
+			expected: []string{"address1", "address2", "address3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Given
+			cfg := &WriterConfig{
+				Brokers: tt.fields.Brokers,
+			}
+
+			// When
+			cfg.removeSpaceBrokerList()
+
+			// Then
+			if !reflect.DeepEqual(cfg.Brokers, tt.expected) {
+				t.Errorf("For broker list %v, expected %v", cfg.Brokers, tt.expected)
+			}
+		})
+	}
 }
 
 func TestProducerConfig_String(t *testing.T) {


### PR DESCRIPTION
Konsumer can't connect to brokers if the list contains spaces in it.

It always tries to connect to the first broker if the list is separated with spaces. 
Therefore, it halts when the list is separated with spaces and the first broker is unreachable.

The pr suggests removing spaces in the broker lists before connecting to brokers.

Related to: https://github.com/Trendyol/kafka-konsumer/issues/135
