### PR TITLE
chore: Update debezium/zookeeper image version

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "4318:4318"
 
   zookeeper:
-    image: debezium/zookeeper
+    image: debezium/zookeeper:2.6
     ports:
       - "2181:2181"
 

--- a/examples/with-grafana/docker-compose.yml
+++ b/examples/with-grafana/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - monitoring
 
   zookeeper:
-    image: debezium/zookeeper
+    image: debezium/zookeeper:2.6
     ports:
       - "2181:2181"
 


### PR DESCRIPTION
When I run docker-compose file which is located at examples. I face with `zookeeper Error    manifest for debezium/zookeeper:latest not found: manifest unknown: manifest unknown `  error, for solving this problem I updated image version of debezium/zookeeper.