### PR TITLE
Make Intermediate CA optional in TLS configuration

### DIFF
--- a/consumer_base.go
+++ b/consumer_base.go
@@ -96,17 +96,17 @@ func NewConsumer(cfg *ConsumerConfig) (Consumer, error) {
 }
 
 func newBase(cfg *ConsumerConfig, messageChSize int) (*base, error) {
-	cfg.Logger = NewZapLogger(cfg.LogLevel)
+	log := NewZapLogger(cfg.LogLevel)
 
 	if err := verifyTopicOnStartup(cfg); err != nil {
 		return nil, err
 	}
 
-	cfg.Logger.Infof("Topic [%s] verified successfully!", cfg.getTopics())
+	log.Infof("Topic [%s] verified successfully!", cfg.getTopics())
 
-	reader, err := cfg.newKafkaReader()
+	reader, err := cfg.newKafkaReader(log)
 	if err != nil {
-		cfg.Logger.Errorf("Error when initializing kafka reader %v", err)
+		log.Errorf("Error when initializing kafka reader %v", err)
 		return nil, err
 	}
 
@@ -119,7 +119,7 @@ func newBase(cfg *ConsumerConfig, messageChSize int) (*base, error) {
 		retryEnabled:              cfg.RetryEnabled,
 		transactionalRetry:        *cfg.TransactionalRetry,
 		distributedTracingEnabled: cfg.DistributedTracingEnabled,
-		logger:                    cfg.Logger,
+		logger:                    log,
 		subprocesses:              newSubProcesses(),
 		r:                         reader,
 		messageGroupDuration:      cfg.MessageGroupDuration,

--- a/consumer_base.go
+++ b/consumer_base.go
@@ -96,17 +96,17 @@ func NewConsumer(cfg *ConsumerConfig) (Consumer, error) {
 }
 
 func newBase(cfg *ConsumerConfig, messageChSize int) (*base, error) {
-	log := NewZapLogger(cfg.LogLevel)
+	cfg.Logger = NewZapLogger(cfg.LogLevel)
 
 	if err := verifyTopicOnStartup(cfg); err != nil {
 		return nil, err
 	}
 
-	log.Infof("Topic [%s] verified successfully!", cfg.getTopics())
+	cfg.Logger.Infof("Topic [%s] verified successfully!", cfg.getTopics())
 
 	reader, err := cfg.newKafkaReader()
 	if err != nil {
-		log.Errorf("Error when initializing kafka reader %v", err)
+		cfg.Logger.Errorf("Error when initializing kafka reader %v", err)
 		return nil, err
 	}
 
@@ -119,7 +119,7 @@ func newBase(cfg *ConsumerConfig, messageChSize int) (*base, error) {
 		retryEnabled:              cfg.RetryEnabled,
 		transactionalRetry:        *cfg.TransactionalRetry,
 		distributedTracingEnabled: cfg.DistributedTracingEnabled,
-		logger:                    log,
+		logger:                    cfg.Logger,
 		subprocesses:              newSubProcesses(),
 		r:                         reader,
 		messageGroupDuration:      cfg.MessageGroupDuration,

--- a/consumer_config.go
+++ b/consumer_config.go
@@ -262,7 +262,7 @@ func (cfg *ConsumerConfig) newKafkaDialer() (*kafka.Dialer, error) {
 		return dialer.Dialer, nil
 	}
 
-	if err := fillLayer(dialer, cfg.SASL, cfg.TLS); err != nil {
+	if err := fillLayer(dialer, cfg.SASL, cfg.TLS, cfg.Logger); err != nil {
 		return nil, err
 	}
 

--- a/consumer_config.go
+++ b/consumer_config.go
@@ -246,7 +246,7 @@ type BatchConfiguration struct {
 	MessageGroupByteSizeLimit any
 }
 
-func (cfg *ConsumerConfig) newKafkaDialer() (*kafka.Dialer, error) {
+func (cfg *ConsumerConfig) newKafkaDialer(logger LoggerInterface) (*kafka.Dialer, error) {
 	dialer := &Dialer{
 		Dialer: &kafka.Dialer{
 			ClientID: cfg.ClientID,
@@ -262,17 +262,17 @@ func (cfg *ConsumerConfig) newKafkaDialer() (*kafka.Dialer, error) {
 		return dialer.Dialer, nil
 	}
 
-	if err := fillLayer(dialer, cfg.SASL, cfg.TLS, cfg.Logger); err != nil {
+	if err := fillLayer(dialer, cfg.SASL, cfg.TLS, logger); err != nil {
 		return nil, err
 	}
 
 	return dialer.Dialer, nil
 }
 
-func (cfg *ConsumerConfig) newKafkaReader() (Reader, error) {
+func (cfg *ConsumerConfig) newKafkaReader(logger LoggerInterface) (Reader, error) {
 	cfg.setDefaults()
 
-	dialer, err := cfg.newKafkaDialer()
+	dialer, err := cfg.newKafkaDialer(logger)
 	if err != nil {
 		return nil, err
 	}

--- a/layer.go
+++ b/layer.go
@@ -11,7 +11,7 @@ type Layer interface {
 	SetSASL(mechanism sasl.Mechanism)
 }
 
-func fillLayer(layer Layer, sasl *SASLConfig, tls *TLSConfig) error {
+func fillLayer(layer Layer, sasl *SASLConfig, tls *TLSConfig, logger LoggerInterface) error {
 	if sasl != nil {
 		mechanism, err := sasl.Mechanism()
 		if err != nil {
@@ -22,7 +22,7 @@ func fillLayer(layer Layer, sasl *SASLConfig, tls *TLSConfig) error {
 	}
 
 	if tls != nil {
-		config, err := tls.TLSConfig()
+		config, err := tls.TLSConfig(logger)
 		if err != nil {
 			return err
 		}

--- a/producer.go
+++ b/producer.go
@@ -45,6 +45,8 @@ func NewProducer(cfg *ProducerConfig, interceptors ...ProducerInterceptor) (Prod
 		AllowAutoTopicCreation: cfg.Writer.AllowAutoTopicCreation,
 	}
 
+	cfg.Logger = NewZapLogger(cfg.LogLevel)
+
 	if cfg.SASL != nil || cfg.TLS != nil {
 		transport, err := cfg.newKafkaTransport()
 		if err != nil {

--- a/producer_config.go
+++ b/producer_config.go
@@ -52,6 +52,8 @@ type TransportConfig struct {
 
 type ProducerConfig struct {
 	DistributedTracingConfiguration DistributedTracingConfiguration
+	Logger                          LoggerInterface
+	LogLevel                        LogLevel
 	Transport                       *TransportConfig
 	SASL                            *SASLConfig
 	TLS                             *TLSConfig
@@ -93,7 +95,7 @@ func (cfg *ProducerConfig) newKafkaTransport() (*kafka.Transport, error) {
 		transport.Transport.MetadataTopics = cfg.Transport.MetadataTopics
 	}
 
-	if err := fillLayer(transport, cfg.SASL, cfg.TLS); err != nil {
+	if err := fillLayer(transport, cfg.SASL, cfg.TLS, cfg.Logger); err != nil {
 		return nil, err
 	}
 

--- a/tls.go
+++ b/tls.go
@@ -18,14 +18,18 @@ func (c *TLSConfig) TLSConfig() (*tls.Config, error) {
 		return nil, fmt.Errorf("Error while reading Root CA file: " + c.RootCAPath + " error: " + err.Error())
 	}
 
-	interCA, err := os.ReadFile(c.IntermediateCAPath)
-	if err != nil {
-		return nil, fmt.Errorf("Error while reading Intermediate CA file: " + c.IntermediateCAPath + " error: " + err.Error())
+	caCertPool := x509.NewCertPool()
+	if ok := caCertPool.AppendCertsFromPEM(rootCA); !ok {
+		return nil, fmt.Errorf("failed to append Root CA certificates from file: %s", c.RootCAPath)
 	}
 
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(rootCA)
-	caCertPool.AppendCertsFromPEM(interCA)
+	interCA, err := os.ReadFile(c.IntermediateCAPath)
+	if err != nil {
+		fmt.Printf("Warning: Unable to read Intermediate CA file: %s, error: %v", c.IntermediateCAPath, err)
+		fmt.Println("Intermediate CA will be skipped.")
+	} else if ok := caCertPool.AppendCertsFromPEM(interCA); !ok {
+		fmt.Printf("Warning: Failed to append Intermediate CA certificates from file: %s", c.IntermediateCAPath)
+	}
 
 	return &tls.Config{RootCAs: caCertPool}, nil //nolint:gosec
 }

--- a/tls.go
+++ b/tls.go
@@ -12,7 +12,7 @@ type TLSConfig struct {
 	IntermediateCAPath string
 }
 
-func (c *TLSConfig) TLSConfig() (*tls.Config, error) {
+func (c *TLSConfig) TLSConfig(logger LoggerInterface) (*tls.Config, error) {
 	rootCA, err := os.ReadFile(c.RootCAPath)
 	if err != nil {
 		return nil, fmt.Errorf("Error while reading Root CA file: " + c.RootCAPath + " error: " + err.Error())
@@ -25,10 +25,10 @@ func (c *TLSConfig) TLSConfig() (*tls.Config, error) {
 
 	interCA, err := os.ReadFile(c.IntermediateCAPath)
 	if err != nil {
-		fmt.Printf("Warning: Unable to read Intermediate CA file: %s, error: %v", c.IntermediateCAPath, err)
-		fmt.Println("Intermediate CA will be skipped.")
+		logger.Warnf("Unable to read Intermediate CA file: %s, error: %v", c.IntermediateCAPath, err)
+		logger.Info("Intermediate CA will be skipped.")
 	} else if ok := caCertPool.AppendCertsFromPEM(interCA); !ok {
-		fmt.Printf("Warning: Failed to append Intermediate CA certificates from file: %s", c.IntermediateCAPath)
+		logger.Warnf("Failed to append Intermediate CA certificates from file: %s", c.IntermediateCAPath)
 	}
 
 	return &tls.Config{RootCAs: caCertPool}, nil //nolint:gosec

--- a/tls_test.go
+++ b/tls_test.go
@@ -5,6 +5,31 @@ import (
 	"testing"
 )
 
+const testRootCA = `-----BEGIN CERTIFICATE-----
+MIIECTCCA3KgAwIBAgIUDnU7Oa0fU9GFOwU7EWJP3HsRchEwDQYJKoZIhvcNAQEL
+BQAwgZkxCzAJBgNVBAYTAlVTMRAwDgYDVQQIDAdNb250YW5hMRAwDgYDVQQHDAdC
+b3plbWFuMREwDwYDVQQKDAhTYXd0b290aDEYMBYGA1UECwwPQ29uc3VsdGluZ18x
+MDI0MRgwFgYDVQQDDA93d3cud29sZnNzbC5jb20xHzAdBgkqhkiG9w0BCQEWEGlu
+Zm9Ad29sZnNzbC5jb20wHhcNMjIxMjE2MjExNzQ5WhcNMjUwOTExMjExNzQ5WjCB
+mTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmExEDAOBgNVBAcMB0JvemVt
+YW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9Db25zdWx0aW5nXzEwMjQx
+GDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqGSIb3DQEJARYQaW5mb0B3
+b2xmc3NsLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAzazdR+y+tyTD
+YxtUmHnhxzEWWdadd52N4ovtBBeyxuvkm5G+MVBil1i1fynes3EkC7+XCX8m3C3s
+qC6yZCt6KzUZLaKAy5n9lHEbI41U2y5ijYEILfQkcids+cmO20x1upsB+D8Y9OZ/
++1eUksyIxLQAwqrU5YgYsxEvc8DWKQkCAwEAAaOCAUowggFGMB0GA1UdDgQWBBTT
+Io8oLOAF7tPtw3E9ybI2Oh2/qDCB2QYDVR0jBIHRMIHOgBTTIo8oLOAF7tPtw3E9
+ybI2Oh2/qKGBn6SBnDCBmTELMAkGA1UEBhMCVVMxEDAOBgNVBAgMB01vbnRhbmEx
+EDAOBgNVBAcMB0JvemVtYW4xETAPBgNVBAoMCFNhd3Rvb3RoMRgwFgYDVQQLDA9D
+b25zdWx0aW5nXzEwMjQxGDAWBgNVBAMMD3d3dy53b2xmc3NsLmNvbTEfMB0GCSqG
+SIb3DQEJARYQaW5mb0B3b2xmc3NsLmNvbYIUDnU7Oa0fU9GFOwU7EWJP3HsRchEw
+DAYDVR0TBAUwAwEB/zAcBgNVHREEFTATggtleGFtcGxlLmNvbYcEfwAAATAdBgNV
+HSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDQYJKoZIhvcNAQELBQADgYEAuIC/
+svWDlVGBan5BhynXw8nGm2DkZaEElx0bO+kn+kPWiWo8nr8o0XU3IfMNZBeyoy2D
+Uv9X8EKpSKrYhOoNgAVxCqojtGzG1n8TSvSCueKBrkaMWfvDjG1b8zLshvBu2ip4
+q/I2+0j6dAkOGcK/68z7qQXByeGri3n28a1Kn6o=
+-----END CERTIFICATE-----`
+
 func TestTLSConfig_TLSConfig(t *testing.T) {
 	// Given
 	rootca, err := os.CreateTemp("", "rootca*.pem")
@@ -18,6 +43,10 @@ func TestTLSConfig_TLSConfig(t *testing.T) {
 		t.Fatalf("Error creating rootca pem temp file %s", err.Error())
 	}
 	defer os.Remove(intermediate.Name())
+
+	if err := os.WriteFile(rootca.Name(), []byte(testRootCA), 0644); err != nil {
+		t.Fatalf("Error writing root CA to file: %s", err.Error())
+	}
 
 	tlsCfg := TLSConfig{
 		RootCAPath:         rootca.Name(),

--- a/tls_test.go
+++ b/tls_test.go
@@ -53,8 +53,10 @@ func TestTLSConfig_TLSConfig(t *testing.T) {
 		IntermediateCAPath: intermediate.Name(),
 	}
 
+	logger := NewZapLogger(LogLevelInfo)
+
 	// When
-	_, err = tlsCfg.TLSConfig()
+	_, err = tlsCfg.TLSConfig(logger)
 	// Then
 	if err != nil {
 		t.Fatalf("Error when settings tls certificates %s", err.Error())

--- a/verify_topic.go
+++ b/verify_topic.go
@@ -29,7 +29,7 @@ func newKafkaClient(cfg *ConsumerConfig) (kafkaClient, error) {
 			MetadataTopics: cfg.getTopics(),
 		},
 	}
-	if err = fillLayer(transport, cfg.SASL, cfg.TLS); err != nil {
+	if err = fillLayer(transport, cfg.SASL, cfg.TLS, cfg.Logger); err != nil {
 		err = fmt.Errorf("error when initializing kafka client for verify topic purpose %w", err)
 		return nil, err
 	}


### PR DESCRIPTION
- Ensure that Root CA is always added to the cert pool.
- If the Intermediate CA file is present, add it to the cert pool.
- Log a warning and skip Intermediate CA if the file is missing or invalid.