### PR TITLE
fix: add missing logger for verify topic

### DIFF
--- a/consumer_base.go
+++ b/consumer_base.go
@@ -98,7 +98,7 @@ func NewConsumer(cfg *ConsumerConfig) (Consumer, error) {
 func newBase(cfg *ConsumerConfig, messageChSize int) (*base, error) {
 	log := NewZapLogger(cfg.LogLevel)
 
-	if err := verifyTopicOnStartup(cfg); err != nil {
+	if err := verifyTopicOnStartup(cfg, log); err != nil {
 		return nil, err
 	}
 
@@ -142,8 +142,8 @@ func newBase(cfg *ConsumerConfig, messageChSize int) (*base, error) {
 	return &c, nil
 }
 
-func verifyTopicOnStartup(cfg *ConsumerConfig) error {
-	kclient, err := newKafkaClient(cfg)
+func verifyTopicOnStartup(cfg *ConsumerConfig, logger LoggerInterface) error {
+	kclient, err := newKafkaClient(cfg, logger)
 	if err != nil {
 		return err
 	}

--- a/verify_topic.go
+++ b/verify_topic.go
@@ -16,7 +16,7 @@ type client struct {
 	*kafka.Client
 }
 
-func newKafkaClient(cfg *ConsumerConfig) (kafkaClient, error) {
+func newKafkaClient(cfg *ConsumerConfig, logger LoggerInterface) (kafkaClient, error) {
 	var err error
 	kc := &client{
 		Client: &kafka.Client{
@@ -29,7 +29,7 @@ func newKafkaClient(cfg *ConsumerConfig) (kafkaClient, error) {
 			MetadataTopics: cfg.getTopics(),
 		},
 	}
-	if err = fillLayer(transport, cfg.SASL, cfg.TLS, cfg.Logger); err != nil {
+	if err = fillLayer(transport, cfg.SASL, cfg.TLS, logger); err != nil {
 		err = fmt.Errorf("error when initializing kafka client for verify topic purpose %w", err)
 		return nil, err
 	}

--- a/verify_topic_test.go
+++ b/verify_topic_test.go
@@ -105,7 +105,7 @@ func Test_newKafkaClient(t *testing.T) {
 	}
 
 	// When
-	client, err := newKafkaClient(cfg)
+	client, err := newKafkaClient(cfg, NewZapLogger(LogLevelDebug))
 
 	// Then
 	if client.GetClient().Addr.String() != "127.0.0.1:9092" {


### PR DESCRIPTION
The issue occurring when a logger is not provided in the consumer config for verify_topics has been fixed.