### PR TITLE
feat: support specifying scram hash algorithm

### DIFF
--- a/mechanism.go
+++ b/mechanism.go
@@ -11,8 +11,10 @@ import (
 type Mechanism string
 
 const (
-	MechanismScram = "scram"
-	MechanismPlain = "plain"
+	MechanismScram       = "scram"
+	MechanismScramSHA256 = "scram-sha-256"
+	MechanismScramSHA512 = "scram-sha-512"
+	MechanismPlain       = "plain"
 )
 
 type SASLConfig struct {
@@ -22,8 +24,12 @@ type SASLConfig struct {
 }
 
 func (s *SASLConfig) Mechanism() (sasl.Mechanism, error) {
-	if s.Type == MechanismScram {
+	if s.Type == MechanismScram || s.Type == MechanismScramSHA512 {
 		return scram.Mechanism(scram.SHA512, s.Username, s.Password)
+	}
+
+	if s.Type == MechanismScramSHA256 {
+		return scram.Mechanism(scram.SHA256, s.Username, s.Password)
 	}
 
 	return s.plain(), nil

--- a/mechanism_test.go
+++ b/mechanism_test.go
@@ -15,15 +15,31 @@ func TestSASLConfig_Json(t *testing.T) {
 			t.Fatal("result must be equal to expected")
 		}
 	})
-	t.Run("Should_Convert_To_Json", func(t *testing.T) {
+	t.Run("Should_Convert_ScramSHA512_To_Json", func(t *testing.T) {
 		// Given
 		cfg := &SASLConfig{
-			Type:     "scram",
+			Type:     MechanismScramSHA512,
 			Username: "user",
 			Password: "pass",
 		}
 
-		expected := "{\"Mechanism\": \"scram\", \"Username\": \"user\", \"Password\": \"pass\"}"
+		expected := "{\"Mechanism\": \"scram-sha-512\", \"Username\": \"user\", \"Password\": \"pass\"}"
+		// When
+		result := cfg.JSON()
+		// Then
+		if result != expected {
+			t.Fatal("result must be equal to expected")
+		}
+	})
+	t.Run("Should_Convert_ScramSHA256_To_Json", func(t *testing.T) {
+		// Given
+		cfg := &SASLConfig{
+			Type:     MechanismScramSHA256,
+			Username: "user",
+			Password: "pass",
+		}
+
+		expected := "{\"Mechanism\": \"scram-sha-256\", \"Username\": \"user\", \"Password\": \"pass\"}"
 		// When
 		result := cfg.JSON()
 		// Then


### PR DESCRIPTION
This pull request adds support for users to select SCRAM-SHA-256 or SCRAM-SHA-512 mechanisms. Additionally, it updates the corresponding tests in `mechanism_test.go` to ensure the new mechanisms are properly handled.