### PR TITLE
fix message count metrics in batch consumer

### DIFF
--- a/batch_consumer.go
+++ b/batch_consumer.go
@@ -238,6 +238,16 @@ func (b *batchConsumer) consume(allMessages *[]*Message, commitMessages *[]kafka
 	*messageByteSizeLimit = 0
 }
 
+func countFailedMessages(chunkMessages []*Message) int64 {
+	var errorCount int64
+	for i := range chunkMessages {
+		if chunkMessages[i].IsFailed {
+			errorCount++
+		}
+	}
+	return errorCount
+}
+
 func (b *batchConsumer) process(chunkMessages []*Message) {
 	consumeErr := b.consumeFn(chunkMessages)
 
@@ -250,7 +260,9 @@ func (b *batchConsumer) process(chunkMessages []*Message) {
 				b.metric.IncrementTotalUnprocessedMessagesCounter(int64(len(chunkMessages)))
 			}
 		} else {
-			b.metric.IncrementTotalUnprocessedMessagesCounter(int64(len(chunkMessages)))
+			failedCount := countFailedMessages(chunkMessages)
+			b.metric.IncrementTotalUnprocessedMessagesCounter(failedCount)
+			b.metric.IncrementTotalProcessedMessagesCounter(int64(len(chunkMessages)) - failedCount)
 		}
 
 		if consumeErr != nil && b.retryEnabled {

--- a/batch_consumer_test.go
+++ b/batch_consumer_test.go
@@ -176,6 +176,30 @@ func Test_batchConsumer_process(t *testing.T) {
 			t.Fatalf("Total Unprocessed Message Counter must equal to 0")
 		}
 	})
+	t.Run("When_Processing_Is_Partial_Successful_And_Transactional_Retry_Disabled", func(t *testing.T) {
+		// Given
+		bc := batchConsumer{
+			base: &base{metric: &ConsumerMetric{}, transactionalRetry: false},
+			consumeFn: func(messages []*Message) error {
+				messages[0].IsFailed = true
+				messages[1].IsFailed = false
+				messages[2].IsFailed = true
+
+				return errors.New("error case")
+			},
+		}
+
+		// When
+		bc.process([]*Message{{}, {}, {}})
+
+		// Then
+		if bc.metric.totalUnprocessedMessagesCounter != 2 {
+			t.Fatalf("Total Unprocessed Message Counter must equal to 2")
+		}
+		if bc.metric.totalProcessedMessagesCounter != 1 {
+			t.Fatalf("Total Processed Message Counter must equal to 1")
+		}
+	})
 	t.Run("When_Re-processing_Is_Successful", func(t *testing.T) {
 		// Given
 		gotOnlyOneTimeException := true


### PR DESCRIPTION
fix message count metrics in batch consumer when processing is partial success and transactional retry is disabled