### PR TITLE
feat: go upgrade 1.24

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.24
 
       - uses: actions/checkout@v4
       - name: Start containers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.24
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,15 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.24
 
       - name: Install dependencies
         run: go get .
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.51
+          version: v1.64.8
           args: -c .golangci.yml --timeout=5m -v
 
       - name: Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,8 +44,3 @@ issues:
         - errcheck
         - gosec
         - funlen
-
-service:
-  golangci-lint-version: 1.51.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 ## lint: runs golangci lint based on .golangci.yml configuration
 .PHONY: lint
 lint:
-	@if ! test -f `go env GOPATH`/bin/golangci-lint; then go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0; fi
+	@if ! test -f `go env GOPATH`/bin/golangci-lint; then go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8; fi
 	golangci-lint run -c .golangci.yml --fix -v
 
 ## test: runs tests

--- a/batch_consumer_test.go
+++ b/batch_consumer_test.go
@@ -229,7 +229,7 @@ func Test_batchConsumer_process(t *testing.T) {
 		// Given
 		bc := batchConsumer{
 			base: &base{metric: &ConsumerMetric{}, transactionalRetry: true, logger: NewZapLogger(LogLevelDebug)},
-			consumeFn: func(messages []*Message) error {
+			consumeFn: func(_ []*Message) error {
 				return errors.New("error case")
 			},
 		}
@@ -253,7 +253,7 @@ func Test_batchConsumer_process(t *testing.T) {
 				metric: &ConsumerMetric{}, transactionalRetry: true,
 				logger: NewZapLogger(LogLevelDebug), retryEnabled: true, cronsumer: &mc,
 			},
-			consumeFn: func(messages []*Message) error {
+			consumeFn: func(_ []*Message) error {
 				return errors.New("error case")
 			},
 		}
@@ -277,7 +277,7 @@ func Test_batchConsumer_process(t *testing.T) {
 				metric: &ConsumerMetric{}, transactionalRetry: true,
 				logger: NewZapLogger(LogLevelDebug), retryEnabled: true, cronsumer: &mc,
 			},
-			consumeFn: func(messages []*Message) error {
+			consumeFn: func(_ []*Message) error {
 				return errors.New("error case")
 			},
 		}
@@ -300,7 +300,7 @@ func Test_batchConsumer_process(t *testing.T) {
 				metric: &ConsumerMetric{}, transactionalRetry: true,
 				logger: NewZapLogger(LogLevelDebug), retryEnabled: true, cronsumer: &mc,
 			},
-			consumeFn: func(messages []*Message) error {
+			consumeFn: func(_ []*Message) error {
 				return errors.New("error case")
 			},
 		}
@@ -506,7 +506,7 @@ func Test_batchConsumer_runKonsumerFn(t *testing.T) {
 	t.Run("Should_Return_Default_Error_When_Error_Description_Does_Not_Exist", func(t *testing.T) {
 		// Given
 		expectedError := errors.New("default error")
-		bc := batchConsumer{consumeFn: func(messages []*Message) error {
+		bc := batchConsumer{consumeFn: func(_ []*Message) error {
 			return expectedError
 		}}
 

--- a/consumer_base.go
+++ b/consumer_base.go
@@ -292,8 +292,9 @@ func initializeDeadLetterProducer(cfg *ConsumerConfig) (Producer, error) {
 
 	deadLetterProducer, err := NewProducer(&ProducerConfig{
 		Writer: WriterConfig{
-			Topic:   deadLetterTopic,
-			Brokers: cfg.Reader.Brokers,
+			Topic:                  deadLetterTopic,
+			Brokers:                cfg.Reader.Brokers,
+			AllowAutoTopicCreation: true,
 		},
 		LogLevel: cfg.LogLevel,
 		SASL:     cfg.SASL,

--- a/consumer_base_test.go
+++ b/consumer_base_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_base_startConsume(t *testing.T) {
-	t.Run("Return_When_Quit_Signal_Is_Came", func(t *testing.T) {
+	t.Run("Return_When_Quit_Signal_Is_Came", func(_ *testing.T) {
 		mc := mockReader{wantErr: true}
 		b := base{
 			wg:                    sync.WaitGroup{},

--- a/data_units.go
+++ b/data_units.go
@@ -11,6 +11,9 @@ func resolveUnionIntOrStringValue(input any) (int, error) {
 	case int:
 		return value, nil
 	case uint:
+		if value > ^uint(0)>>1 {
+			return 0, fmt.Errorf("uint value %d overflows int", value)
+		}
 		return int(value), nil
 	case nil:
 		return 0, nil

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/Trendyol/kafka-konsumer/v2
 
-go 1.19
+go 1.24
 
 require (
-	github.com/Trendyol/kafka-cronsumer v1.6.6
+	github.com/Trendyol/kafka-cronsumer v1.6.7
 	github.com/Trendyol/otel-kafka-konsumer v0.0.7
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1
 	github.com/gofiber/fiber/v2 v2.52.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Trendyol/kafka-cronsumer v1.6.6 h1:etPzMQNCUy7t40IjJjA2pTRqggq7jdl6GmqqMJTwjUQ=
-github.com/Trendyol/kafka-cronsumer v1.6.6/go.mod h1:yBs+7SMxqHuQPU1fjyjn1sKIulnD5s1oOfeVysN9pso=
+github.com/Trendyol/kafka-cronsumer v1.6.7 h1:ECWudVShtfk93v9fLwklRbzFX/A+niVcHe9iZgp6cjo=
+github.com/Trendyol/kafka-cronsumer v1.6.7/go.mod h1:dmQ6NWogs/0nmHvwWW5uvoFUsQJkCfQTA9y8ANwyz5A=
 github.com/Trendyol/otel-kafka-konsumer v0.0.7 h1:sT1TE2rgfsdrJWrXKz5j6dPkKJsvP+Tv0Dea4ORqJ+4=
 github.com/Trendyol/otel-kafka-konsumer v0.0.7/go.mod h1:zdCaFclzRCO9fzcjxkHrWOB3I2+uTPrmkq4zczkD1F0=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
@@ -7,6 +7,7 @@ github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/ansrivas/fiberprometheus/v2 v2.6.1 h1:wac3pXaE6BYYTF04AC6K0ktk6vCD+MnDOJZ3SK66kXM=
 github.com/ansrivas/fiberprometheus/v2 v2.6.1/go.mod h1:MloIKvy4yN6hVqlRpJ/jDiR244YnWJaQC0FIqS8A+MY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
@@ -48,6 +49,7 @@ github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFu
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=
@@ -70,6 +72,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.51.0 h1:8b30A5JlZ6C7AS81RsWjYMQmrZG6feChmgAolCl1SqA=

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,6 +1,6 @@
 module integration-test
 
-go 1.19
+go 1.24
 
 replace github.com/Trendyol/kafka-konsumer/v2 => ../..
 
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/Trendyol/kafka-cronsumer v1.5.6 // indirect
+	github.com/Trendyol/kafka-cronsumer v1.6.7 // indirect
 	github.com/Trendyol/otel-kafka-konsumer v0.0.7 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/ansrivas/fiberprometheus/v2 v2.6.1 // indirect

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -12,6 +12,8 @@ github.com/Trendyol/kafka-cronsumer v1.5.4/go.mod h1:VpweJmKY+6dppFhzWOZDbZfxBNu
 github.com/Trendyol/kafka-cronsumer v1.5.5-0.20241024185446-b44371b7a3ec/go.mod h1:VpweJmKY+6dppFhzWOZDbZfxBNuJkSxB12CcuZWBNFU=
 github.com/Trendyol/kafka-cronsumer v1.5.5/go.mod h1:VpweJmKY+6dppFhzWOZDbZfxBNuJkSxB12CcuZWBNFU=
 github.com/Trendyol/kafka-cronsumer v1.5.6/go.mod h1:yBs+7SMxqHuQPU1fjyjn1sKIulnD5s1oOfeVysN9pso=
+github.com/Trendyol/kafka-cronsumer v1.6.6/go.mod h1:yBs+7SMxqHuQPU1fjyjn1sKIulnD5s1oOfeVysN9pso=
+github.com/Trendyol/kafka-cronsumer v1.6.7/go.mod h1:dmQ6NWogs/0nmHvwWW5uvoFUsQJkCfQTA9y8ANwyz5A=
 github.com/Trendyol/otel-kafka-konsumer v0.0.7 h1:sT1TE2rgfsdrJWrXKz5j6dPkKJsvP+Tv0Dea4ORqJ+4=
 github.com/Trendyol/otel-kafka-konsumer v0.0.7/go.mod h1:zdCaFclzRCO9fzcjxkHrWOB3I2+uTPrmkq4zczkD1F0=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=


### PR DESCRIPTION
## Summary

Upgrades the project-wide Go version from **1.19** to **1.24** and updates all related tooling to ensure full compatibility.

## Changes

### Go Version Upgrade
- **`go.mod`** — Bumped `go 1.19` → `go 1.24`
- **`test/integration/go.mod`** — Bumped `go 1.19` → `go 1.24`
- **`.github/workflows/test.yml`** — Updated `go-version` from `1.19` to `1.24`
- **`.github/workflows/release.yml`** — Updated `go-version` from `1.19` to `1.24`
- **`.github/workflows/integration-test.yml`** — Updated `go-version` from `1.19` to `1.24`

### golangci-lint Upgrade
golangci-lint **v1.51** only supports up to Go 1.20 and is incompatible with Go 1.24. Updated to **v1.64.8** (the last v1.x release with Go 1.24 support).

- **`.github/workflows/test.yml`** — Bumped `golangci/golangci-lint-action` from `v3` to `v6`, and lint version from `v1.51` to `v1.64.8`
- **`Makefile`** — Updated local install target from `v1.51.0` to `v1.64.8`
- **`.golangci.yml`** — Removed the deprecated `service` block which is no longer a valid configuration key in v1.64+

### Lint Fixes
The newer golangci-lint version introduced stricter checks. The following issues were resolved:

- **`data_units.go`** — Added overflow guard for `uint` → `int` conversion to satisfy `gosec` rule G115
- **`batch_consumer_test.go`** (5 occurrences) — Renamed unused `messages` parameter to `_` to satisfy `revive` unused-parameter rule
- **`consumer_base_test.go`** — Renamed unused `t` parameter to `_` to satisfy `revive` unused-parameter rule

### Dead Letter Producer Fix
- **`consumer_base.go`** — Added `AllowAutoTopicCreation: true` to the dead letter producer's `WriterConfig`. Previously, when running integration tests in parallel, the dead letter topic metadata might not have propagated across the broker in time, causing a `[3] Unknown Topic Or Partition` panic during dead letter message production.

## Affected Files

| File | Type of Change |
|------|---------------|
| `go.mod` | Go version bump |
| `test/integration/go.mod` | Go version bump |
| `.github/workflows/test.yml` | Go version + lint tooling upgrade |
| `.github/workflows/release.yml` | Go version bump |
| `.github/workflows/integration-test.yml` | Go version bump |
| `.golangci.yml` | Remove deprecated config |
| `Makefile` | Lint tooling upgrade |
| `data_units.go` | Lint fix (overflow guard) |
| `batch_consumer_test.go` | Lint fix (unused params) |
| `consumer_base_test.go` | Lint fix (unused params) |
| `consumer_base.go` | Bug fix (dead letter topic creation) |