### PR TITLE
docs(examples): add README files for six example directories

### DIFF
--- a/examples/with-deadletter/README.md
+++ b/examples/with-deadletter/README.md
@@ -1,0 +1,52 @@
+### Dead Letter Topic
+
+This example demonstrates how to configure retry logic and a dead-letter topic using `kafka-konsumer`.
+When message processing fails, the library automatically retries via a retry topic, and after exhausting
+all retries it routes the message to a dead-letter topic for manual inspection.
+
+### Prerequisites
+
+- Go 1.21+
+- A running Kafka broker (see [docker-compose.yml](../docker-compose.yml))
+- Three Kafka topics:
+  - `standart-topic` — main consumption topic
+  - `retry-topic` — intermediate retry topic
+  - `error-topic` — dead-letter topic
+
+### How to run demo?
+
+Start the Kafka broker:
+
+```sh
+docker-compose up -d
+```
+
+Run the consumer:
+
+```sh
+go run main.go
+```
+
+The `consumeFn` in this example always returns an error, so every message will be retried once and
+then forwarded to `error-topic`. You can verify this by consuming from the dead-letter topic:
+
+```sh
+kafka-console-consumer --bootstrap-server localhost:29092 --topic error-topic --from-beginning
+```
+
+### Configuration
+
+| Field                          | Value          | Description                                        |
+|--------------------------------|----------------|----------------------------------------------------|
+| `RetryEnabled`                 | true           | Enables automatic retry on processing failure      |
+| `RetryConfiguration.MaxRetry` | 1              | Maximum number of retry attempts before dead-letter|
+| `RetryConfiguration.Topic`    | retry-topic    | Topic where failed messages are temporarily queued |
+| `RetryConfiguration.DeadLetterTopic` | error-topic | Final destination for unrecoverable messages  |
+| `StartTimeCron`                | `*/1 * * * *` | Retry worker start schedule (every minute)         |
+| `WorkDuration`                 | 50s            | Duration the retry worker runs per cron tick       |
+
+### Limitation
+
+The retry cron schedule runs on a one-minute interval, so there may be a short delay before retried
+messages are reprocessed. For immediate retry behaviour consider using a shorter `WorkDuration` or
+a more frequent cron expression.

--- a/examples/with-kafka-batch-consumer/README.md
+++ b/examples/with-kafka-batch-consumer/README.md
@@ -1,0 +1,61 @@
+### Batch Consumer
+
+This example demonstrates how to consume messages in batches using `kafka-konsumer`.
+Instead of processing one message at a time, the batch consumer collects up to
+`MessageGroupLimit` messages within a `MessageGroupDuration` window and passes them
+all at once to `BatchConsumeFn`. This pattern is well-suited for bulk database writes,
+aggregation, and other workloads that benefit from processing multiple records together.
+
+### Prerequisites
+
+- Go 1.21+
+- A running Kafka broker (see [docker-compose.yml](../docker-compose.yml))
+
+### How to run demo?
+
+Start the Kafka broker:
+
+```sh
+docker-compose up -d
+```
+
+Load the topic with sample data using the provided load file:
+
+```sh
+kafka-console-producer --broker-list localhost:29092 --topic standart-topic < ../load.txt
+```
+
+Run the batch consumer:
+
+```sh
+go run main.go
+```
+
+You will see output like:
+
+```
+100 comes first {"id":1,...}
+```
+
+### Configuration
+
+| Field                              | Value          | Description                                              |
+|------------------------------------|----------------|----------------------------------------------------------|
+| `BatchConfiguration.MessageGroupLimit` | 1000       | Maximum messages collected before calling `BatchConsumeFn` |
+| `MessageGroupDuration`             | 1s             | Maximum wait time before flushing an incomplete batch    |
+| `RetryEnabled`                     | true           | Enables retry for batches that return an error           |
+| `RetryConfiguration.MaxRetry`      | 3              | Maximum retry attempts per batch                         |
+
+### Key Difference from Single Consumer
+
+| Feature              | Single Consumer     | Batch Consumer                    |
+|----------------------|---------------------|-----------------------------------|
+| Handler signature    | `func(*Message) error` | `func([]*Message) error`       |
+| Throughput           | Lower               | Higher (amortises per-call cost)  |
+| Error granularity    | Per message         | Entire batch is retried on error  |
+
+### Limitation
+
+When `BatchConsumeFn` returns an error the entire batch is retried, not individual messages.
+Ensure your handler is idempotent, or implement internal per-message error tracking and always
+return `nil` from `BatchConsumeFn` after handling partial failures.

--- a/examples/with-kafka-producer/README.md
+++ b/examples/with-kafka-producer/README.md
@@ -1,0 +1,56 @@
+### Kafka Producer
+
+This example demonstrates how to use the built-in `kafka-konsumer` producer to publish single
+messages and batches of messages to a Kafka topic.
+
+### Prerequisites
+
+- Go 1.21+
+- A running Kafka broker (see [docker-compose.yml](../docker-compose.yml))
+
+### How to run demo?
+
+Start the Kafka broker:
+
+```sh
+docker-compose up -d
+```
+
+Run the producer:
+
+```sh
+go run main.go
+```
+
+The program produces one individual message and a batch of two messages to `standart-topic`, then exits.
+You can verify the messages were delivered:
+
+```sh
+kafka-console-consumer --bootstrap-server localhost:29092 --topic standart-topic --from-beginning
+```
+
+### API
+
+**Produce a single message:**
+
+```go
+_ = producer.Produce(context.Background(), kafka.Message{
+    Topic: "my-topic",
+    Key:   []byte("key"),
+    Value: []byte(`{"hello": "world"}`),
+})
+```
+
+**Produce a batch of messages:**
+
+```go
+_ = producer.ProduceBatch(context.Background(), []kafka.Message{
+    {Topic: "my-topic", Key: []byte("1"), Value: []byte(`{"a": 1}`)},
+    {Topic: "my-topic", Key: []byte("2"), Value: []byte(`{"a": 2}`)},
+})
+```
+
+### Limitation
+
+This example omits error handling for brevity. In production code, always check the error returned
+by `Produce` and `ProduceBatch` and implement appropriate retry or alerting logic.

--- a/examples/with-prometheus/README.md
+++ b/examples/with-prometheus/README.md
@@ -1,0 +1,59 @@
+### Prometheus Metrics
+
+This example demonstrates how to enable the built-in Prometheus metrics endpoint in `kafka-konsumer`.
+When `APIEnabled` is set to `true`, the library exposes an HTTP server with a `/metrics` endpoint
+compatible with Prometheus scraping.
+
+### Prerequisites
+
+- Go 1.21+
+- A running Kafka broker (see [docker-compose.yml](../docker-compose.yml))
+- (Optional) A running Prometheus instance to scrape metrics
+
+### How to run demo?
+
+Start the Kafka broker:
+
+```sh
+docker-compose up -d
+```
+
+Run the consumer:
+
+```sh
+go run main.go
+```
+
+Once running, metrics are available at:
+
+```
+http://localhost:8090/metrics
+```
+
+You can verify with:
+
+```sh
+curl http://localhost:8090/metrics
+```
+
+### Key Configuration
+
+| Field        | Value  | Description                                          |
+|--------------|--------|------------------------------------------------------|
+| `APIEnabled` | true   | Enables the built-in HTTP metrics server             |
+| `LogLevel`   | Debug  | Verbose logging for development and troubleshooting  |
+
+### Available Metrics
+
+`kafka-konsumer` exposes consumer-level metrics including:
+
+- Total messages consumed
+- Total messages failed
+- Retry queue depth
+- Consumer lag (offset-based)
+
+### Limitation
+
+The default metrics port is `8090`. If you need to change it, refer to the `ConsumerConfig.APIPort`
+field. The metrics endpoint does not require authentication; in production environments ensure network
+policies restrict access appropriately.

--- a/examples/with-sasl-plaintext/README.md
+++ b/examples/with-sasl-plaintext/README.md
@@ -1,0 +1,57 @@
+### SASL PLAINTEXT Authentication
+
+This example demonstrates how to connect to a Kafka broker that requires SASL PLAINTEXT
+authentication. This is a common setup in managed Kafka environments and internal clusters
+that enforce access control via username and password.
+
+### Prerequisites
+
+- Go 1.21+
+- A Kafka broker configured with SASL PLAINTEXT (see [docker-compose.yml](docker-compose.yml) in this directory)
+
+### How to run demo?
+
+Start the Kafka broker with SASL enabled using the local docker-compose file:
+
+```sh
+docker-compose up -d
+```
+
+> **Note:** This example has its own `docker-compose.yml` and `configs/` directory, separate from
+> the shared one at the examples root, because it requires a broker with SASL configured.
+
+Run the consumer:
+
+```sh
+go run main.go
+```
+
+### SASL Configuration
+
+```go
+SASL: &kafka.SASLConfig{
+    Type:     kafka.MechanismPlain,
+    Username: "client",
+    Password: "client-secret",
+},
+```
+
+| Field      | Description                                      |
+|------------|--------------------------------------------------|
+| `Type`     | Authentication mechanism — `MechanismPlain` here |
+| `Username` | SASL username configured on the broker           |
+| `Password` | SASL password configured on the broker           |
+
+### Supported Mechanisms
+
+`kafka-konsumer` supports the following SASL mechanisms:
+
+- `MechanismPlain` — SASL/PLAIN (username + password, plaintext)
+- `MechanismScramSha256` — SASL/SCRAM-SHA-256
+- `MechanismScramSha512` — SASL/SCRAM-SHA-512
+
+### Limitation
+
+SASL PLAINTEXT transmits credentials without transport-level encryption. For production deployments
+combine SASL with TLS to protect credentials in transit. See the `TLS` field in `ConsumerConfig`
+for TLS setup.

--- a/examples/with-standalone-consumer/README.md
+++ b/examples/with-standalone-consumer/README.md
@@ -1,0 +1,46 @@
+### Standalone Consumer
+
+This example demonstrates the simplest way to consume messages from a Kafka topic using `kafka-konsumer`.
+It sets up a single-partition consumer with no retry logic — ideal for getting started quickly.
+
+### Prerequisites
+
+- Go 1.21+
+- A running Kafka broker (see [docker-compose.yml](../docker-compose.yml))
+
+### How to run demo?
+
+Start the Kafka broker using the shared docker-compose file at the examples root:
+
+```sh
+docker-compose up -d
+```
+
+Then run the consumer:
+
+```sh
+go run main.go
+```
+
+You should see messages printed to stdout as they are consumed from `standart-topic`.
+
+To produce test messages into the topic you can use the Kafka console producer:
+
+```sh
+kafka-console-producer --broker-list localhost:29092 --topic standart-topic
+```
+
+### Configuration
+
+| Field         | Value            | Description                          |
+|---------------|------------------|--------------------------------------|
+| `Brokers`     | localhost:29092  | Kafka broker address                 |
+| `Topic`       | standart-topic   | Topic to consume from                |
+| `GroupID`     | standart-cg      | Consumer group identifier            |
+| `Concurrency` | 1                | Number of concurrent message workers |
+| `RetryEnabled`| false            | Retry is disabled in this example    |
+
+### Limitation
+
+This example has no retry or dead-letter configuration. Failed messages will be skipped.
+For retry support, see the [with-deadletter](../with-deadletter) example.


### PR DESCRIPTION
Closes #40

This PR adds `README.md` files to six example directories that were previously missing documentation. The structure follows the pattern already established in `examples/with-tracing/README.md` and the checklist from issue #40.

## Added READMEs

| Example | What it covers |
|---|---|
| `with-standalone-consumer` | Simplest single-topic consumer, no retry |
| `with-deadletter` | Retry + dead-letter topic routing on failure |
| `with-kafka-producer` | Single and batch message production |
| `with-prometheus` | Built-in metrics endpoint via `APIEnabled` |
| `with-sasl-plaintext` | SASL PLAIN authentication with broker |
| `with-kafka-batch-consumer` | High-throughput batch processing with `BatchConsumeFn` |

Each README includes: description, prerequisites, step-by-step run instructions, configuration table, and a limitations section.

No source code was changed — documentation only.