### PR TITLE
fix: prevent panic when transactional batch retry succeeds

### DIFF
--- a/batch_consumer.go
+++ b/batch_consumer.go
@@ -296,7 +296,7 @@ func (b *batchConsumer) process(chunkMessages []*Message) {
 				b.metric.IncrementTotalProcessedMessagesCounter(int64(len(remainingMessages)) - failedCount)
 			}
 
-			if b.retryEnabled {
+			if consumeErr != nil && b.retryEnabled {
 				cronsumerMessages := make([]kcronsumer.Message, 0, len(remainingMessages))
 				if b.transactionalRetry {
 					for i := range remainingMessages {

--- a/batch_consumer_test.go
+++ b/batch_consumer_test.go
@@ -225,38 +225,6 @@ func Test_batchConsumer_process(t *testing.T) {
 			t.Fatalf("Total Unprocessed Message Counter must equal to 0")
 		}
 	})
-	t.Run("When_Re-processing_Is_Successful_And_Retry_Enabled_Should_Not_Send_To_Retry_Topic", func(t *testing.T) {
-		// Given
-		gotOnlyOneTimeException := true
-		mc := &mockCronsumer{}
-		bc := batchConsumer{
-			base: &base{
-				metric: &ConsumerMetric{}, transactionalRetry: true,
-				logger: NewZapLogger(LogLevelDebug), retryEnabled: true, cronsumer: mc,
-			},
-			consumeFn: func(_ []*Message) error {
-				if gotOnlyOneTimeException {
-					gotOnlyOneTimeException = false
-					return errors.New("simulate only one time exception")
-				}
-				return nil
-			},
-		}
-
-		// When
-		bc.process([]*Message{{}, {}, {}})
-
-		// Then
-		if bc.metric.totalProcessedMessagesCounter != 3 {
-			t.Fatalf("Total Processed Message Counter must equal to 3")
-		}
-		if bc.metric.totalUnprocessedMessagesCounter != 0 {
-			t.Fatalf("Total Unprocessed Message Counter must equal to 0")
-		}
-		if mc.produceBatchCalls != 0 {
-			t.Fatalf("ProduceBatch must not be called when transactional retry succeeds, got %d calls", mc.produceBatchCalls)
-		}
-	})
 	t.Run("When_Re-processing_Is_Failed_And_Retry_Disabled", func(t *testing.T) {
 		// Given
 		bc := batchConsumer{
@@ -483,6 +451,39 @@ func Test_batchConsumer_process(t *testing.T) {
 		// When && Then
 		bc.process(msgs)
 	})
+}
+
+func Test_batchConsumer_process_When_Reprocessing_Succeeds_And_Retry_Enabled_Should_Not_Send_To_Retry_Topic(t *testing.T) {
+	// Given
+	gotOnlyOneTimeException := true
+	mc := &mockCronsumer{}
+	bc := batchConsumer{
+		base: &base{
+			metric: &ConsumerMetric{}, transactionalRetry: true,
+			logger: NewZapLogger(LogLevelDebug), retryEnabled: true, cronsumer: mc,
+		},
+		consumeFn: func(_ []*Message) error {
+			if gotOnlyOneTimeException {
+				gotOnlyOneTimeException = false
+				return errors.New("simulate only one time exception")
+			}
+			return nil
+		},
+	}
+
+	// When
+	bc.process([]*Message{{}, {}, {}})
+
+	// Then
+	if bc.metric.totalProcessedMessagesCounter != 3 {
+		t.Fatalf("Total Processed Message Counter must equal to 3")
+	}
+	if bc.metric.totalUnprocessedMessagesCounter != 0 {
+		t.Fatalf("Total Unprocessed Message Counter must equal to 0")
+	}
+	if mc.produceBatchCalls != 0 {
+		t.Fatalf("ProduceBatch must not be called when transactional retry succeeds, got %d calls", mc.produceBatchCalls)
+	}
 }
 
 func Test_batchConsumer_Pause(t *testing.T) {

--- a/batch_consumer_test.go
+++ b/batch_consumer_test.go
@@ -225,6 +225,38 @@ func Test_batchConsumer_process(t *testing.T) {
 			t.Fatalf("Total Unprocessed Message Counter must equal to 0")
 		}
 	})
+	t.Run("When_Re-processing_Is_Successful_And_Retry_Enabled_Should_Not_Send_To_Retry_Topic", func(t *testing.T) {
+		// Given
+		gotOnlyOneTimeException := true
+		mc := &mockCronsumer{}
+		bc := batchConsumer{
+			base: &base{
+				metric: &ConsumerMetric{}, transactionalRetry: true,
+				logger: NewZapLogger(LogLevelDebug), retryEnabled: true, cronsumer: mc,
+			},
+			consumeFn: func(_ []*Message) error {
+				if gotOnlyOneTimeException {
+					gotOnlyOneTimeException = false
+					return errors.New("simulate only one time exception")
+				}
+				return nil
+			},
+		}
+
+		// When
+		bc.process([]*Message{{}, {}, {}})
+
+		// Then
+		if bc.metric.totalProcessedMessagesCounter != 3 {
+			t.Fatalf("Total Processed Message Counter must equal to 3")
+		}
+		if bc.metric.totalUnprocessedMessagesCounter != 0 {
+			t.Fatalf("Total Unprocessed Message Counter must equal to 0")
+		}
+		if mc.produceBatchCalls != 0 {
+			t.Fatalf("ProduceBatch must not be called when transactional retry succeeds, got %d calls", mc.produceBatchCalls)
+		}
+	})
 	t.Run("When_Re-processing_Is_Failed_And_Retry_Disabled", func(t *testing.T) {
 		// Given
 		bc := batchConsumer{
@@ -749,6 +781,7 @@ type mockCronsumer struct {
 	retryBehaviorOpen bool
 	times             int
 	maxRetry          int
+	produceBatchCalls int
 }
 
 func (m *mockCronsumer) Start() {
@@ -786,6 +819,7 @@ func (m *mockCronsumer) GetMetricCollectors() []prometheus.Collector {
 }
 
 func (m *mockCronsumer) ProduceBatch([]kcronsumer.Message) error {
+	m.produceBatchCalls++
 	if m.retryBehaviorOpen {
 		if m.wantErr && m.times <= m.maxRetry {
 			m.times++

--- a/message.go
+++ b/message.go
@@ -116,6 +116,9 @@ func getErrorMessage(consumeErr error, msg *Message) string {
 	if msg.ErrDescription != "" {
 		return msg.ErrDescription
 	}
+	if consumeErr == nil {
+		return ""
+	}
 	return consumeErr.Error()
 }
 


### PR DESCRIPTION
Restore consumeErr nil guard before sending batch messages to retry topic, aligning batch consumer behavior with single consumer.

Also make getErrorMessage nil-safe as defense in depth.

Fixes Trendyol/kafka-konsumer#195